### PR TITLE
Resolve list key leaves from the path predicate

### DIFF
--- a/src/gnyang/gnmi.act
+++ b/src/gnyang/gnmi.act
@@ -103,6 +103,16 @@ extension proto.Notification(YangData):
             if tv is not None:
                 return (op=None, t=tv.t, val=tv.val)
 
+        # A list key leaf usually has no update of its own: its value lives in the
+        # path predicate (e.g. interface[name=mgmt0]). Recover it from the prefix's
+        # last element's keys so the non-optional key still resolves.
+        if len(self.prefix.elems) > 0:
+            for k, v in self.prefix.elems[-1].keys:
+                if k == name:
+                    tv = try_parse_leaf_value(v, schema, schema.type_, new_path, root)
+                    if tv is not None:
+                        return (op=None, t=tv.t, val=tv.val)
+
         return None
 
 

--- a/src/gnyang/test_data.act
+++ b/src/gnyang/test_data.act
@@ -213,6 +213,41 @@ def _test_y1_gnmi_take_leaf():
     else:
         raise Exception()
 
+def _test_y1_gnmi_key_from_predicate():
+    """A gNMI server may carry a list key only in the path predicate (l2[k1=...]),
+    not as a separate update for the key leaf. from_gnmi_notif must still resolve
+    the non-optional key leaf from the predicate rather than failing with
+    "Cannot find child node". This mirrors what Nokia SR Linux sends."""
+    y1 = r"""module y1 {
+  namespace "urn:example:y1";
+  prefix y1;
+
+  container c1 {
+    list l2 {
+      key "k1";
+      leaf k1 {
+        type string;
+      }
+      leaf v1 {
+        type string;
+      }
+    }
+  }
+}"""
+
+    # Note: there is NO update for .../k1 — the key value lives only in the
+    # l2[k1=Key 1] predicate, exactly as SR Linux streams it.
+    notif_in = Notification(0, Path([], '', ''),
+                           [Update(Path([PathElem('c1', []), PathElem('l2', [('k1', 'Key 1')]), PathElem('v1', [])], '', ''), StringValue('Value for v1'), 0)
+                            ],
+                           [], False)
+
+    s = yang.compile([y1])
+    gd = from_gnmi_notif(s, notif_in)
+    src = gd.prsrc()
+    testing.assertEqual('Key 1' in src, True)
+    testing.assertEqual('Value for v1' in src, True)
+
 def _test_y1_gnmi():
     y1 = r"""module y1 {
   namespace "urn:example:y1";

--- a/src/gnyang/test_data.act
+++ b/src/gnyang/test_data.act
@@ -248,6 +248,59 @@ def _test_y1_gnmi_key_from_predicate():
     testing.assertEqual('Key 1' in src, True)
     testing.assertEqual('Value for v1' in src, True)
 
+def _test_y1_gnmi_multi_key_from_predicate():
+    """Both keys of a multi-key list, carried only in the predicate, must resolve."""
+    ym = r"""module ym {
+  namespace "urn:example:ym";
+  prefix ym;
+
+  list l {
+    key "a b";
+    leaf a { type string; }
+    leaf b { type string; }
+    leaf v { type string; }
+  }
+}"""
+
+    notif_in = Notification(0, Path([], '', ''),
+                           [Update(Path([PathElem('l', [('a', 'A1'), ('b', 'B1')]), PathElem('v', [])], '', ''), StringValue('val'), 0)
+                            ],
+                           [], False)
+
+    s = yang.compile([ym])
+    gd = from_gnmi_notif(s, notif_in)
+    src = gd.prsrc()
+    testing.assertEqual('A1' in src, True)
+    testing.assertEqual('B1' in src, True)
+
+def _test_y1_gnmi_nested_no_keyleak():
+    """A leaf named like the parent list's key, but nested in a container with its
+    own update, must keep its own value and not inherit the list key (the fix only
+    reads elems[-1], and take_container pushes an empty-keys PathElem)."""
+    yn = r"""module yn {
+  namespace "urn:example:yn";
+  prefix yn;
+
+  list l {
+    key "k1";
+    leaf k1 { type string; }
+    container inner {
+      leaf k1 { type string; }
+    }
+  }
+}"""
+
+    notif_in = Notification(0, Path([], '', ''),
+                           [Update(Path([PathElem('l', [('k1', 'OUTER')]), PathElem('inner', []), PathElem('k1', [])], '', ''), StringValue('INNER'), 0)
+                            ],
+                           [], False)
+
+    s = yang.compile([yn])
+    gd = from_gnmi_notif(s, notif_in)
+    src = gd.prsrc()
+    testing.assertEqual('OUTER' in src, True)
+    testing.assertEqual('INNER' in src, True)
+
 def _test_y1_gnmi():
     y1 = r"""module y1 {
   namespace "urn:example:y1";


### PR DESCRIPTION
A gNMI server carries a list entry's key in the path predicate, e.g. interface[name=mgmt0], rather than sending a separate update for the key leaf itself. take_leaf only matched an update by leaf name, so when traversal reached a non-optional key leaf there was no value and decoding aborted with "Cannot find child node with name name". This recovers the key leaf's value from the enclosing list element's key predicate when there is no explicit update for it. Verified end to end against Nokia SR Linux: an /interface[name=mgmt0]/statistics subscription now decodes into a proper gdata tree instead of failing.