### PR TITLE
Upgrade grpc for the response-header debug fix

### DIFF
--- a/Build.act
+++ b/Build.act
@@ -3,8 +3,8 @@ fingerprint = 0x21c13a9a49111a8a
 dependencies = {
     "grpc": (
         repo_url="https://github.com/actonlang/acton-grpc.git",
-        url="https://github.com/actonlang/acton-grpc/archive/1bb2871d05a105f4b4dfe294f68af9a7e1870150.zip",
-        hash="N-V-__8AAKYfAAAvzbqHS7MadYOeLLaEdTOXTkaRrDUg2UTS"
+        url="https://github.com/actonlang/acton-grpc/archive/480661917e1281a1e9c1f59dc5d42a7a3a3e716b.zip",
+        hash="N-V-__8AADggAADkMv6-s6EAlx4MPaj3naV_W-a4G7hZYqR_"
     ),
     "yang": (
         repo_url="https://github.com/orchestron-orchestrator/acton-yang.git",


### PR DESCRIPTION
Run acton pkg upgrade to bump grpc to its current main, which now logs received response headers at debug instead of printing them to stdout. yang is unchanged (already at the latest).