### PR TITLE
Use the per-subscription stream mode in Subscribe

### DIFF
--- a/src/lib.act
+++ b/src/lib.act
@@ -74,7 +74,7 @@ actor Client(cap: net.TCPConnectCap, target: str, on_connect: action(Client) -> 
         use_models: list[proto.ModelData] = []
 
         for path in paths:
-            subscriptions.append(proto.Subscription(path, mode, sample_interval, False, sample_interval))
+            subscriptions.append(proto.Subscription(path, stream_mode, sample_interval, False, sample_interval))
 
         request = proto.SubscribeRequest(proto.SubscriptionList(prefix, subscriptions, qos, mode, allow_aggregation, use_models, encoding, updates_only))
         payload: bytes = request.pack()


### PR DESCRIPTION
subscribe() built each Subscription with the SubscriptionList mode (STREAM) instead of the per-subscription stream_mode, and never used stream_mode at all. STREAM is 0, which as a Subscription mode means TARGET_DEFINED, so a SAMPLE request carrying a sample_interval went out as TARGET_DEFINED and the target ignored the interval and used its own cadence (~5s on Nokia SR Linux). Pass stream_mode so SAMPLE with sample_interval is actually requested. Verified against SR Linux: a 1s sample interval now delivers updates at ~1s instead of ~5s.